### PR TITLE
Add AGENTS.md, CLAUDE.md, and REVIEW.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS
+
+## review
+
+Always review in Japanese.
+
+## github
+
+- 機能実装時はデフォルトブランチへのPRを作成する
+- ある程度の単位でcommit、pushしPRとissueが存在すれば更新する
+- PRに付いた指摘が無いか都度確認してあれば必要な対応か検討して、必要なら修正する
+  - 付いた指摘に対してはcommit idをつけて返答をしてresolveする
+- PRのスコープ外の問題が発覚した場合は別途issueを作成する
+- issueの解決を目的とした場合は修正中都度issueの本文を更新し必要に応じてコメントをつける

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,3 @@
+# review
+
+Always review in Japanese.


### PR DESCRIPTION
## 概要

`limit7412/analytics_notifications_slack` から以下の 3 ファイルを移植しました。

| ファイル | 内容 |
|---|---|
| `AGENTS.md` | review（日本語レビュー指定）+ github 運用ルール |
| `CLAUDE.md` | `@AGENTS.md`（AGENTS.md を参照） |
| `REVIEW.md` | review（日本語レビュー指定） |

移植元の `master` ブランチの内容をそのまま反映しています。

https://claude.ai/code/session_01Dmn1mXVPDYByX341kBPh62

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dmn1mXVPDYByX341kBPh62)_