### PR TITLE
ci: clasp workflowをbackend変更時のみ実行するよう限定

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -5,7 +5,12 @@ env:
   DEPLOYMENT: ${{ secrets.DEV_DEPLOYMENT }}
   SCRIPT_ID: ${{ secrets.DEV_SCRIPT_ID }}
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.clasp.json'
+      - '.github/workflows/backend-dev.yml'
 
 jobs:
   deploy:

--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -16,6 +16,8 @@ jobs:
   deploy:
     name: deploy-clasp
     runs-on: ubuntu-latest
+    # dependabot起因の実行はsecretsを参照できずデプロイも不要なため除外する
+    if: github.actor != 'dependabot[bot]'
 
     steps:
 

--- a/.github/workflows/backend-prod.yml
+++ b/.github/workflows/backend-prod.yml
@@ -17,6 +17,8 @@ jobs:
   deploy:
     name: deploy-clasp
     runs-on: ubuntu-latest
+    # dependabot起因の実行はsecretsを参照できずデプロイも不要なため除外する
+    if: github.actor != 'dependabot[bot]'
 
     steps:
 

--- a/.github/workflows/backend-prod.yml
+++ b/.github/workflows/backend-prod.yml
@@ -8,6 +8,10 @@ env:
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'backend/**'
+      - '.clasp.json'
+      - '.github/workflows/backend-prod.yml'
 
 jobs:
   deploy:


### PR DESCRIPTION
## 概要

Closes #148

dependabotが生成するPRでclaspが失敗する問題を修正します。

## 原因

`backend-dev.yml` は `on: pull_request` で全PRに対してclaspのpush/deployを実行していました。しかし:

1. dependabotが生成するPRは `package.json` / `package-lock.json`（Nuxtフロントエンドの依存）のみを変更し、claspでデプロイする `backend/`（Google Apps Script）には触れません。
2. dependabotのPRはリポジトリのsecretsにアクセスできないため、`CLASPRC_JSON` / `DEV_DEPLOYMENT` / `DEV_SCRIPT_ID` が空になり、`clasp push --force` が失敗していました。

## 対応

claspワークフローに `paths` フィルタを追加し、backend関連ファイルが変更されたときのみ実行するよう限定しました。

- `backend/**`
- `.clasp.json`
- ワークフロー自身

これにより、backendに無関係なdependabot PRではclaspが起動せず、不要な失敗が発生しなくなります。あわせて `backend-prod.yml`（master push）にも同様のフィルタを追加し、backend変更時のみデプロイするよう整理しました。

## テスト

- 両ワークフローのYAML妥当性を確認済み

https://claude.ai/code/session_01GeiatBi4vENaQDHCrZRZNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeiatBi4vENaQDHCrZRZNz)_