### PR TITLE
fix: プレビュービルドがprodバックエンドを参照する問題を修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,8 @@
 
-const envSet = require(`./env.${process.env.NODE_ENV || 'production'}.js`)
+// `nuxi build`/`generate` は NODE_ENV を強制的に production へ書き換えるため、
+// バックエンド切り替えには NODE_ENV ではなく APP_ENV を優先して参照する。
+const appEnv = process.env.APP_ENV || process.env.NODE_ENV || 'production'
+const envSet = require(`./env.${appEnv}.js`)
 
 export default defineNuxtConfig({
   mode: 'universal',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,8 +1,18 @@
 
-// `nuxi build`/`generate` は NODE_ENV を強制的に production へ書き換えるため、
-// バックエンド切り替えには NODE_ENV ではなく APP_ENV を優先して参照する。
-const appEnv = process.env.APP_ENV || process.env.NODE_ENV || 'production'
-const envSet = require(`./env.${appEnv}.js`)
+// Cloudflare Pages は build command を Preview/Production で分けられないため、
+// デプロイ環境を環境変数で判定してバックエンドを切り替える。
+// - APP_ENV: 明示指定の最優先（ローカル検証用）
+// - CF_PAGES_BRANCH: Cloudflare Pages が自動設定するデプロイ元ブランチ。
+//   本番ブランチ(master)以外のプレビューデプロイは development を使う。
+// - それ以外（ローカル）は NODE_ENV を見て最終的に production へフォールバック。
+//   なお nuxi build/generate は NODE_ENV を production へ強制変更する。
+function resolveAppEnv() {
+  if (process.env.APP_ENV) return process.env.APP_ENV
+  const cfBranch = process.env.CF_PAGES_BRANCH
+  if (cfBranch && cfBranch !== 'master') return 'development'
+  return process.env.NODE_ENV === 'development' ? 'development' : 'production'
+}
+const envSet = require(`./env.${resolveAppEnv()}.js`)
 
 export default defineNuxtConfig({
   mode: 'universal',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "cross-env NODE_ENV=\"production\" npx nuxi build",
     "start": "cross-env NODE_ENV=\"production\" npx nuxi start",
     "generate": "cross-env NODE_ENV=\"production\" NITRO_PRESET=cloudflare_pages npx nuxi generate",
+    "generate:preview": "cross-env APP_ENV=\"development\" NITRO_PRESET=cloudflare_pages npx nuxi generate",
     "postinstall": "nuxi prepare",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## 概要

PRごとに生成されるプレビュービルドのバックエンドアクセス先がprodになっていた問題を修正します。

## 原因

バックエンドAPIのURLは `nuxt.config.js` で env ファイルを選択する仕組みでしたが、判定に `NODE_ENV` を使っていました。`nuxi build` / `nuxi generate` は実行時に **`NODE_ENV` を強制的に `production` へ書き換える**（ビルドログに `Changing NODE_ENV from development to production` が出る）ため、プレビュービルドでも常に `env.production.js`（prodバックエンド）が埋め込まれていました。

加えて Cloudflare Pages は **ビルドコマンドを Preview / Production で分けられない**ため、ビルドコマンドの差し替えで切り替えることもできません。

## 修正方針

ビルドコマンドは単一のまま、**Cloudflare Pages が自動でセットする `CF_PAGES_BRANCH` でデプロイ環境を判定**してバックエンドを切り替えます。**Cloudflare 側の設定変更は不要**です。

`nuxt.config.js` の env 選択ロジック（優先順）:

1. `APP_ENV`（明示指定。ローカル検証用の最優先オーバーライド）
2. `CF_PAGES_BRANCH`（Cloudflare が自動設定）が本番ブランチ `master` 以外 → `development`
3. それ以外はローカルとみなし `NODE_ENV` を参照、最終的に `production` へフォールバック

## 動作

| シナリオ | 参照バックエンド |
| --- | --- |
| Cloudflare 本番デプロイ（master, `CF_PAGES_BRANCH=master`） | prod |
| Cloudflare プレビューデプロイ（PRブランチ） | **dev** |
| ローカル `npm run dev` | dev |
| ローカル `npm run generate` | prod |
| ローカル `npm run generate:preview`（`APP_ENV=development`、検証用） | dev |

## 検証

全シナリオで生成物に埋め込まれるバックエンドURLが期待どおりであることを確認済み。`npm run lint` / `npm run typecheck` パス。

https://claude.ai/code/session_011nXKNEQsaSVa8A148ZzsHk