### PR TITLE
docs: README/ワークフロー名/バッジを現行構成に整合 (Phase 5)

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -1,4 +1,4 @@
-name: clasp
+name: backend-dev
 
 env:
   CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}

--- a/.github/workflows/backend-prod.yml
+++ b/.github/workflows/backend-prod.yml
@@ -1,4 +1,4 @@
-name: clasp
+name: backend-prod
 
 env:
   CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}

--- a/README.md
+++ b/README.md
@@ -1,34 +1,59 @@
 # bs-ageo9.org
-![clasp](https://github.com/bs-ageo09/bs-ageo9.org/workflows/clasp/badge.svg?branch=master)
+![frontend-ci](https://github.com/bs-ageo09/bs-ageo9.org/actions/workflows/frontend-ci.yml/badge.svg?branch=master)
+![backend-prod](https://github.com/bs-ageo09/bs-ageo9.org/actions/workflows/backend-prod.yml/badge.svg?branch=master)
 
 website of 9th Ageo Group, Saitama Scout Council, SAJ
 
 ## frontend
-cloudflare pages + nuxt.js(generate static page)
 
-``` bash
-# install dependencies
-$ npm i
+Nuxt 3（SPA）+ Cloudflare Pages。
 
-# serve with hot reload at localhost:3000
-$ npm run dev
-
-# generate static project
-$ npm run generate
-```
-
-## backend
-google app script + typescript + clasp
-
-frontend configuration
-> ./env.xxx.js
+バックエンド（GAS）へは CORS を回避するため、同一オリジンのサーバープロキシ
+`server/api/backend`（Cloudflare Pages Functions として動作）経由でアクセスする。
+データは実行時に取得するため、スプレッドシートの更新が再ビルドなしで反映される。
 
 ```bash
-# installation deployment tool
+# 依存インストール
+$ npm i
+
+# 開発サーバ（http://localhost:3000）
+$ npm run dev
+
+# ビルド（Cloudflare Pages 向け。dist/ に _worker.js を含む成果物を出力）
+$ npm run generate
+
+# lint / 型チェック / 整形
+$ npm run lint
+$ npm run typecheck
+$ npm run format
+```
+
+バックエンド接続先は `.env.development` / `.env.production` の `BACKEND_API` で設定する。
+デプロイ環境（dev/prod）は Cloudflare が自動設定する `CF_PAGES_BRANCH` で判定し、
+master 以外のプレビューは dev バックエンドを参照する（`APP_ENV` で明示上書きも可能）。
+
+## backend
+
+Google Apps Script + TypeScript + clasp（v3）。
+
+clasp v3 は TypeScript を自動トランスパイルしないため、esbuild で GAS 互換の JS に
+バンドル（`backend/` → `dist-gas/`）してから push する。`doGet` などのエントリポイントは
+バンドル時に `globalThis` へ公開している。
+
+```bash
+# バンドル
+$ npm run build:backend
+
+# 型チェック / lint（ソースに対して実行）
+$ npm run typecheck:backend
+$ npm run lint:backend
+
+# 手動デプロイする場合
 $ npm i -g @google/clasp
 $ clasp login
-
-# upload and deployment (rewriting of .clasp.json is required for execution)
-$ clasp push
-$ clasp open
+$ npm run build:backend
+$ clasp push   # .clasp.json の rootDir は ./dist-gas
 ```
+
+デプロイは GitHub Actions が自動実行する（`backend-dev.yml` = PR で dev、
+`backend-prod.yml` = master push で prod）。


### PR DESCRIPTION
## 概要

#149 の **Phase 5（仕上げ）** です。ドキュメントとワークフロー名を現行構成に合わせて整備します。

## 変更内容

### README 刷新
- frontend: **Nuxt 3（SPA）+ Cloudflare Pages**、バックエンドは**同一オリジンプロキシ `server/api/backend` 経由**（CORS 回避・実行時取得で即時反映）であることを記載
- backend: **clasp v3 + esbuild バンドル**手順（`build:backend` → `dist-gas` → `clasp push`）、`doGet` の global 公開、`.env.*` の `BACKEND_API` と `CF_PAGES_BRANCH` 判定を記載
- 廃止済みの `env.xxx.js` 記述・旧 clasp 手順を削除
- スクリプト一覧（dev / generate / lint / typecheck / format / build:backend 等）を更新

### ワークフロー名・バッジ整合
- `backend-dev.yml` / `backend-prod.yml` の `name` が両方 `clasp` で重複しバッジが曖昧だったため、`backend-dev` / `backend-prod` に変更
- README バッジを `frontend-ci` / `backend-prod` の actions バッジに更新

## 動作確認（ローカル・回帰）
- ✅ `npm run lint` / `typecheck` / `typecheck:backend` / `build:backend` / `generate` すべて green

## 補足
- これにより #149 のフェーズ計画（Phase 0〜5）が完了します。残課題として **Nuxt 3 → 4 のメジャー移行**のみ別途（要方針決定）。

Refs #149

https://claude.ai/code/session_01QyYm7CwxJw4Z7PmhFHhgc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyYm7CwxJw4Z7PmhFHhgc8)_