### PR TITLE
ci: 非backendなPRでdeploy-claspが永久待機する問題を解消

### DIFF
--- a/.github/workflows/backend-dev-skip.yml
+++ b/.github/workflows/backend-dev-skip.yml
@@ -1,0 +1,25 @@
+name: backend-dev-skip
+
+# backend-dev.yml は paths フィルタで「backend に関連する PR」のときだけ起動する。
+# しかし deploy-clasp を required status check にしている場合、backend に関連しない
+# PR では backend-dev.yml 自体が起動せず、チェックが報告されないため
+# "Expected — Waiting for status to be reported" のまま永久に詰まってしまう。
+#
+# そこで backend-dev.yml と逆の paths-ignore で起動し、同名ジョブ deploy-clasp を
+# 即座に成功として報告するダミーを用意することで、非 backend な PR でも
+# required check を満たせるようにする（GitHub 公式が推奨する skip パターン）。
+on:
+  pull_request:
+    paths-ignore:
+      - 'backend/**'
+      - '.clasp.json'
+      - '.github/workflows/backend-dev.yml'
+
+jobs:
+  deploy:
+    name: deploy-clasp
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: skip (no backend changes)
+      run: echo "backend に関連しない変更のため clasp デプロイをスキップします。"


### PR DESCRIPTION
## 概要

バックエンドに関連しない PR を作成したとき、`deploy-clasp` が
`Expected — Waiting for status to be reported` のまま完了もスキップもされず、
UI 上でマージがブロックされる問題を解消します。

## 原因

`deploy-clasp` はブランチ保護の required status check に設定されている一方で、
それを生成する `backend-dev.yml` が片側のパスフィルタ（`paths: backend/** 等`）を
持っています。

GitHub Actions の仕様上、**ワークフロー自体がパスフィルタで起動しなかった場合**、
そのジョブのチェックは「報告されない」状態になります。required check はその報告を
待ち続けるため、非バックエンド PR では永久に `Waiting for status to be reported` の
まま詰まります（GitHub 既知の挙動）。

| PR の内容 | backend-dev.yml | deploy-clasp |
| --- | --- | --- |
| backend に関連する | 起動する | 報告される ✅ |
| backend に関連しない | 起動しない | **永久に待機** ❌ |

`frontend-ci.yml` は `paths-ignore: backend/**` を使っているため非バックエンド PR でも
走り、この問題は起きていません。`backend-dev.yml` だけが片側フィルタのため詰まります。

## 対応

GitHub 公式が推奨する「skipped but required checks」対策パターンを採用します。
`backend-dev.yml` と逆の `paths-ignore` で起動し、同名ジョブ `deploy-clasp` を
即座に成功として報告するだけの軽量なコンパニオンワークフロー
`backend-dev-skip.yml` を追加しました。

- 非バックエンド PR → `backend-dev-skip.yml` が起動し `deploy-clasp` を成功報告 → required check を満たす
- バックエンド PR → 従来どおり `backend-dev.yml` が起動して実デプロイ

実デプロイ用ワークフロー（`backend-dev.yml` / `backend-prod.yml`）には一切手を
入れていないため、デプロイ動作への影響はありません。既存の
`frontend-ci`（paths-ignore）/ `backend-ci`（paths）の対構成と同じ思想です。

## 補足

ブランチ保護で required にしているチェック名がジョブ名 `deploy-clasp` と完全一致して
いる前提です。もし設定側が別名であれば併せてご確認ください。

https://claude.ai/code/session_01UZAVWAwcBWvmjXZKNmRKh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZAVWAwcBWvmjXZKNmRKh9)_