### PR TITLE
docs: README の Nuxt 3 記載を Nuxt 4 に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ website of 9th Ageo Group, Saitama Scout Council, SAJ
 
 ## frontend
 
-Nuxt 3（SPA）+ Cloudflare Pages。
+Nuxt 4（SPA）+ Cloudflare Pages。
 
 バックエンド（GAS）へは CORS を回避するため、同一オリジンのサーバープロキシ
 `server/api/backend`（Cloudflare Pages Functions として動作）経由でアクセスする。


### PR DESCRIPTION
## 概要

README の frontend 説明に残っていた「Nuxt 3」を、実情（#166 で Nuxt 4 + `app/` 構成へ移行済み）に合わせて **「Nuxt 4」** へ修正します。

## 変更
- `README.md`: `Nuxt 3（SPA）` → `Nuxt 4（SPA）`（他に Nuxt のバージョン記載は無し）

ドキュメントのみの変更です。

Refs #149, #164

https://claude.ai/code/session_01QyYm7CwxJw4Z7PmhFHhgc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyYm7CwxJw4Z7PmhFHhgc8)_